### PR TITLE
remaining dependencies

### DIFF
--- a/pkgs/by-name/gz/gz-cmake/package.nix
+++ b/pkgs/by-name/gz/gz-cmake/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gz-cmake";
+  version = "4.0.0";
+
+  src = fetchFromGitHub {
+    owner = "gazebosim";
+    repo = "gz-cmake";
+    rev = "gz-cmake${lib.head (lib.splitString "." finalAttrs.version)}_${finalAttrs.version}";
+    hash = "sha256-r1XQqx+JqH+ITZIaixgZjA/9weyPq8+LQ1N2ZsIdOK4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  strictDeps = true;
+
+  postPatch = ''
+    # Install under lib/cmake instead of share/cmake
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'set(gz_config_install_dir "''${CMAKE_INSTALL_DATAROOTDIR}/cmake/''${PROJECT_NAME_LOWER}")' 'set(gz_config_install_dir "''${GZ_LIB_INSTALL_DIR}/cmake/''${PROJECT_NAME_LOWER}")' \
+  '';
+
+  doCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "A set of CMake modules that are used by the C++-based Gazebo projects";
+    homepage = "https://github.com/gazebosim/gz-cmake";
+    changelog = "https://github.com/gazebosim/gz-cmake/blob/${finalAttrs.src.rev}/Changelog.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+    mainProgram = "gz-cmake";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/gz/gz-common/package.nix
+++ b/pkgs/by-name/gz/gz-common/package.nix
@@ -1,0 +1,190 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  nix-update-script,
+  cmake,
+  assimp,
+  ffmpeg,
+  freeimage,
+  gdal,
+  gz-cmake,
+  gz-math,
+  gz-utils,
+  libuuid,
+  spdlog,
+  tinyxml-2,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "gz-common";
+  version = "6.0.2";
+
+  src = fetchFromGitHub {
+    owner = "gazebosim";
+    repo = "gz-common";
+    rev = "gz-common${lib.head (lib.splitString "." finalAttrs.version)}_${finalAttrs.version}";
+    hash = "sha256-sY9g+AatS+ddYSUAjqumfZNi2JIc+DFbiVYMaWKMC78=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs =
+    [
+      gz-cmake
+      gz-utils
+      spdlog
+      libuuid
+    ]
+    ++ lib.optionals (!finalAttrs.cmakeDefinitions.SKIP_av) [
+      ffmpeg
+    ]
+    ++ lib.optionals (!finalAttrs.cmakeDefinitions.SKIP_events) [
+      gz-math
+    ]
+    ++ lib.optionals (!finalAttrs.cmakeDefinitions.SKIP_geospatial) [
+      gdal
+      gz-math
+    ]
+    ++ lib.optionals (!finalAttrs.cmakeDefinitions.SKIP_graphics) [
+      assimp
+
+      # The package freeimage is currently marked unstable due to upstream inactivity,
+      # but gz-sim requires gz-common to compile with component graphics.
+      # See the gz-common upstream issue https://github.com/gazebosim/gz-common/issues/388
+      freeimage
+
+      gz-math
+      tinyxml-2
+    ]
+    ++ lib.optionals (!finalAttrs.cmakeDefinitions.SKIP_io) [
+      gz-math
+    ];
+
+  strictDeps = true;
+
+  patches = [
+    # Add missing #include <chrono> for Event.hh that uses std::chrono
+    # From pull request https://github.com/gazebosim/gz-common/pull/664
+    (fetchpatch {
+      url = "https://github.com/gazebosim/gz-common/commit/683493c6068c243e158f7e097af8d0ccde04b787.patch?full_inedx=1";
+      hash = "sha256-e4b0UYm42t7LQQQHx/3Jco8V09PF4mScdGiBCkWS4AU=";
+    })
+  ];
+
+  postPatch = ''
+    homeDirForTests="$PWD/test-home-dir"
+    mkdir -p "$homeDirForTests"
+    substituteInPlace src/SystemPaths_TEST.cc \
+      --replace-fail 'homeDir = "/home"' "homeDir = \"$homeDirForTests\""
+  '';
+
+  cmakeDefinitions = {
+    CMAKE_CXX_STANDARD = "23";
+    SKIP_av = false;
+    SKIP_events = false;
+    SKIP_geospatial = false;
+    SKIP_graphics = false;
+    SKIP_io = false;
+    SKIP_profiler = false;
+  };
+
+  cmakeFlags =
+    # TODO(@ShamrockLee):
+    # Remove after a unified way to specify CMake definitions becomes available.
+    lib.mapAttrsToList (
+      n: v:
+      let
+        specifiedType = finalAttrs.cmakeDefinitionTypes.${n} or "";
+        type =
+          if specifiedType != "" then
+            specifiedType
+          else if lib.isBool v then
+            "bool"
+          else
+            "string";
+      in
+      if lib.toUpper type == "BOOL" then lib.cmakeBool n v else lib.cmakeOptionType type n v
+    ) finalAttrs.cmakeDefinitions;
+
+  doCheck = true;
+
+  # Some test cases generate files (probably FIFOs or sockets)
+  # which cannot afford parallel running.
+  enableParallelChecking = false;
+
+  preCheck = ''
+    export HOME="$homeDirForTests/alice"
+    mkdir -p "$HOME"
+  '';
+
+  postCheck = ''
+    rm -r "$homeDirForTests"
+    export HOME="/homeless-shelter"
+  '';
+
+  passthru = {
+    tests =
+      let
+        attrsNotSkipped = lib.filterAttrs (n: v: lib.hasPrefix "SKIP_" n && !v) finalAttrs.cmakeDefinitions;
+      in
+      lib.mapAttrs' (
+        n: _:
+        let
+          component = lib.removePrefix "SKIP_" n;
+        in
+        {
+          name = "dependency-${component}";
+          value = finalAttrs.finalPackage.overrideAttrs (previousAttrs: {
+            cmakeDefinitions = previousAttrs.cmakeDefinitions // lib.mapAttrs (n': _: n != n') attrsNotSkipped;
+            inherit component;
+            preConfigure =
+              ''
+                _cmakePath=$(type -p cmake)
+                cmake() {
+                  "$_cmakePath" "$@" | tee -a cmake_output.log
+                }
+              ''
+              + previousAttrs.preConfigure or "";
+            postConfigure =
+              previousAttrs.postConfigure or ""
+              + ''
+                unset cmake
+                if grep --fixed-strings "Skipping the component [$component] because the following packages are missing" cmake_output.log; then
+                  echo "ERROR: dependencies of component $component is not satisfied."
+                  exit 1
+                fi
+              '';
+          });
+        }
+      ) attrsNotSkipped
+      // {
+        dependency-minimal = finalAttrs.finalPackage.overrideAttrs (previousAttrs: {
+          cmakeDefinitions = previousAttrs.cmakeDefinitions // lib.mapAttrs (n': _: true) attrsNotSkipped;
+        });
+      };
+
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Gazebo common library";
+
+    longDescription = ''
+      '
+            An audio-visual library supports processing audio and video files,
+            a graphics library can load a variety 3D mesh file formats into a generic in-memory representation,
+            and the core library of Gazebo Common containing functionality that spans Base64 encoding/decoding to thread pools
+    '';
+    homepage = "https://github.com/gazebosim/gz-common";
+    changelog = "https://github.com/gazebosim/gz-common/blob/${finalAttrs.src.rev}/Changelog.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+    mainProgram = "gz-common";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/gz/gz-fuel-tools/package.nix
+++ b/pkgs/by-name/gz/gz-fuel-tools/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  pkg-config,
+  curl,
+  gz-cmake,
+  gz-common,
+  gz-math,
+  gz-msgs,
+  gz-tools,
+  gz-utils,
+  jsoncpp,
+  libuuid,
+  libyaml,
+  libzip,
+  protobuf,
+  python3,
+  spdlog,
+  tinyxml-2,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gz-fuel-tools";
+  version = "10.0.0";
+
+  src = fetchFromGitHub {
+    owner = "gazebosim";
+    repo = "gz-fuel-tools";
+    rev = "gz-fuel-tools${lib.head (lib.splitString "." finalAttrs.version)}_${finalAttrs.version}";
+    hash = "sha256-9WskZnci7D09aW32lzmdtlhRBM+hcmhG6iNgf3OC1js=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+
+    # For standard CMake module FindPackageHandleStandardArgs.cmake
+    python3
+  ];
+
+  buildInputs = [
+    curl
+    gz-cmake
+    gz-common
+    gz-math
+    gz-msgs
+    gz-tools
+    gz-utils
+    jsoncpp
+    libyaml
+    libzip
+    protobuf
+    tinyxml-2
+
+    # For gz-common6-targets.cmake provided by gz-common
+    libuuid
+    spdlog
+  ];
+
+  strictDeps = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Client library and command line tools for interacting with Gazebo Fuel servers";
+    homepage = "https://github.com/gazebosim/gz-fuel-tools";
+    changelog = "https://github.com/gazebosim/gz-fuel-tools/blob/${finalAttrs.src.rev}/Changelog.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+    mainProgram = "gz-fuel-tools";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/gz/gz-gui/package.nix
+++ b/pkgs/by-name/gz/gz-gui/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  gz-cmake,
+  gz-common,
+  gz-math,
+  gz-transport,
+  gz-msgs,
+  gz-plugin,
+  gz-tools
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "gz-gui";
+  version = "9.0.0";
+
+  src = fetchFromGitHub {
+    owner = "gazebosim";
+    repo = "gz-gui";
+    rev = "gz-gui${lib.head (lib.splitString "." finalAttrs.version)}_${finalAttrs.version}";
+    hash = "sha256-/YJW6XmdGwbyd5Nx3wcTqnRlpwE1unVGaNX91qfZmiM=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    gz-cmake
+    gz-common
+    gz-math
+    gz-transport
+    gz-msgs
+    gz-plugin
+    gz-tools
+  ];
+
+  strictDeps = true;
+
+  cmakeFlags =
+    # TODO(@ShamrockLee):
+    # Remove after a unified way to specify CMake definitions becomes available.
+    lib.mapAttrsToList (
+      n: v:
+      let
+        specifiedType = finalAttrs.cmakeDefinitionTypes.${n} or "";
+        type =
+          if specifiedType != "" then
+            specifiedType
+          else if lib.isBool v then
+            "bool"
+          else
+            "string";
+      in
+      if lib.toUpper type == "BOOL" then lib.cmakeBool n v else lib.cmakeOptionType type n v
+    ) finalAttrs.cmakeDefinitions;
+
+  doCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Builds on top of Qt to provide widgets which are useful when developing robotics applications, such as a 3D view, plots, dashboard, etc, and can be used together in a convenient unified interface";
+    homepage = "https://github.com/gazebosim/gz-gui";
+    changelog = "https://github.com/gazebosim/gz-gui/blob/${finalAttrs.src.rev}/Changelog.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+    mainProgram = "gz-gui";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/gz/gz-math/package.nix
+++ b/pkgs/by-name/gz/gz-math/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  eigen,
+  gz-cmake,
+  gz-utils,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "gz-math";
+  version = "8.0.0";
+
+  src = fetchFromGitHub {
+    owner = "gazebosim";
+    repo = "gz-math";
+    rev = "gz-math${lib.head (lib.splitString "." finalAttrs.version)}_${finalAttrs.version}";
+    hash = "sha256-3+846hhsaBaiFLIURlXQx6Z1+VYfp9UZgjdl96JvrRw=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    eigen
+    gz-cmake
+    gz-utils
+  ];
+
+  strictDeps = true;
+
+  cmakeDefinitions = {
+    SKIP_SWIG = true;
+    SKIP_PYBIND11 = true;
+  };
+
+  cmakeFlags =
+    # TODO(@ShamrockLee):
+    # Remove after a unified way to specify CMake definitions becomes available.
+    lib.mapAttrsToList (
+      n: v:
+      let
+        specifiedType = finalAttrs.cmakeDefinitionTypes.${n} or "";
+        type =
+          if specifiedType != "" then
+            specifiedType
+          else if lib.isBool v then
+            "bool"
+          else
+            "string";
+      in
+      if lib.toUpper type == "BOOL" then lib.cmakeBool n v else lib.cmakeOptionType type n v
+    ) finalAttrs.cmakeDefinitions;
+
+  doCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "General purpose math library for robot applications";
+    homepage = "https://github.com/gazebosim/gz-math";
+    changelog = "https://github.com/gazebosim/gz-math/blob/${finalAttrs.src.rev}/Changelog.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+    mainProgram = "gz-math";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/gz/gz-msgs/package.nix
+++ b/pkgs/by-name/gz/gz-msgs/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  python3,
+  gz-cmake,
+  gz-math,
+  gz-tools,
+  gz-utils,
+  protobuf,
+  tinyxml-2,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gz-msgs";
+  version = "11.0.0";
+
+  src = fetchFromGitHub {
+    owner = "gazebosim";
+    repo = "gz-msgs";
+    rev = "gz-msgs${lib.head (lib.splitString "." finalAttrs.version)}_${finalAttrs.version}";
+    hash = "sha256-EGf8LJHq1YICUC5kvutJDyFIK7QnpiTjB8fxaOAOHyQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    python3
+  ];
+
+  buildInputs = [
+    gz-cmake
+    gz-math
+    gz-tools
+    gz-utils
+    protobuf
+    tinyxml-2
+  ];
+
+  strictDeps = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Messages for Gazebo robot simulation";
+    homepage = "https://github.com/gazebosim/gz-msgs";
+    changelog = "https://github.com/gazebosim/gz-msgs/blob/${finalAttrs.src.rev}/Changelog.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+    mainProgram = "gz-msgs";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/gz/gz-physics/package.nix
+++ b/pkgs/by-name/gz/gz-physics/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  gz-cmake,
+  gz-common,
+  gz-math,
+  gz-plugin,
+  libsdformat
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "gz-physics";
+  version = "8.0.0";
+
+  src = fetchFromGitHub {
+    owner = "gazebosim";
+    repo = "gz-physics";
+    rev = "gz-physics${lib.head (lib.splitString "." finalAttrs.version)}_${finalAttrs.version}";
+    hash = "sha256-PjwrJG3xvRYrkHDTaBUgoaW8NglEYDPuJrk4QjJjTHU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    gz-cmake
+    gz-common
+    gz-math
+    gz-plugin
+    libsdformat
+  ];
+
+  strictDeps = true;
+
+  cmakeFlags =
+    # TODO(@ShamrockLee):
+    # Remove after a unified way to specify CMake definitions becomes available.
+    lib.mapAttrsToList (
+      n: v:
+      let
+        specifiedType = finalAttrs.cmakeDefinitionTypes.${n} or "";
+        type =
+          if specifiedType != "" then
+            specifiedType
+          else if lib.isBool v then
+            "bool"
+          else
+            "string";
+      in
+      if lib.toUpper type == "BOOL" then lib.cmakeBool n v else lib.cmakeOptionType type n v
+    ) finalAttrs.cmakeDefinitions;
+
+  doCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Abstract physics interface designed to support simulation and rapid development of robot applications";
+    homepage = "https://github.com/gazebosim/gz-physics";
+    changelog = "https://github.com/gazebosim/gz-physics/blob/${finalAttrs.src.rev}/Changelog.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+    mainProgram = "gz-physics";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/gz/gz-plugin/package.nix
+++ b/pkgs/by-name/gz/gz-plugin/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  gz-cmake
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "gz-plugin";
+  version = "3.0.0";
+
+  src = fetchFromGitHub {
+    owner = "gazebosim";
+    repo = "gz-plugin";
+    rev = "gz-plugin${lib.head (lib.splitString "." finalAttrs.version)}_${finalAttrs.version}";
+    hash = "sha256-h2Dx0KcFmJlS67q0v1zbd9nQkTCKgHkxt5KKTT5v+fw=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    gz-cmake
+  ];
+
+  strictDeps = true;
+
+  cmakeFlags =
+    # TODO(@ShamrockLee):
+    # Remove after a unified way to specify CMake definitions becomes available.
+    lib.mapAttrsToList (
+      n: v:
+      let
+        specifiedType = finalAttrs.cmakeDefinitionTypes.${n} or "";
+        type =
+          if specifiedType != "" then
+            specifiedType
+          else if lib.isBool v then
+            "bool"
+          else
+            "string";
+      in
+      if lib.toUpper type == "BOOL" then lib.cmakeBool n v else lib.cmakeOptionType type n v
+    ) finalAttrs.cmakeDefinitions;
+
+  doCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Cross-platform C++ library for dynamically loading plugins";
+    homepage = "https://github.com/gazebosim/gz-plugin";
+    changelog = "https://github.com/gazebosim/gz-plugin/blob/${finalAttrs.src.rev}/Changelog.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+    mainProgram = "gz-plugin";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/gz/gz-rendering/package.nix
+++ b/pkgs/by-name/gz/gz-rendering/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  gz-cmake,
+  gz-common,
+  gz-math,
+  gz-plugin
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "gz-rendering";
+  version = "9.0.0";
+
+  src = fetchFromGitHub {
+    owner = "gazebosim";
+    repo = "gz-rendering";
+    rev = "gz-rendering${lib.head (lib.splitString "." finalAttrs.version)}_${finalAttrs.version}";
+    hash = "sha256-e3OPLeqV6OgjnQrbpwRj59e7Z0BqN2wOee/gAaMHfqU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    gz-cmake
+    gz-common
+    gz-math
+    gz-plugin
+  ];
+
+  strictDeps = true;
+
+  cmakeFlags =
+    # TODO(@ShamrockLee):
+    # Remove after a unified way to specify CMake definitions becomes available.
+    lib.mapAttrsToList (
+      n: v:
+      let
+        specifiedType = finalAttrs.cmakeDefinitionTypes.${n} or "";
+        type =
+          if specifiedType != "" then
+            specifiedType
+          else if lib.isBool v then
+            "bool"
+          else
+            "string";
+      in
+      if lib.toUpper type == "BOOL" then lib.cmakeBool n v else lib.cmakeOptionType type n v
+    ) finalAttrs.cmakeDefinitions;
+
+  doCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "C++ library designed to provide an abstraction for different rendering engines";
+    homepage = "https://github.com/gazebosim/gz-rendering";
+    changelog = "https://github.com/gazebosim/gz-rendering/blob/${finalAttrs.src.rev}/Changelog.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+    mainProgram = "gz-rendering";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/gz/gz-sensors/package.nix
+++ b/pkgs/by-name/gz/gz-sensors/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  gz-cmake,
+  gz-common,
+  gz-math,
+  gz-transport,
+  gz-msgs,
+  gz-rendering
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "gz-sensors";
+  version = "9.0.0";
+
+  src = fetchFromGitHub {
+    owner = "gazebosim";
+    repo = "gz-sensors";
+    rev = "gz-gui${lib.head (lib.splitString "." finalAttrs.version)}_${finalAttrs.version}";
+    hash = "sha256-8Ato7/YRL7JebbVPASD6VF9lf/Uyq26MIg2l+jQ4GDk=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    gz-cmake
+    gz-common
+    gz-math
+    gz-transport
+    gz-msgs
+    gz-rendering
+  ];
+
+  strictDeps = true;
+
+  cmakeFlags =
+    # TODO(@ShamrockLee):
+    # Remove after a unified way to specify CMake definitions becomes available.
+    lib.mapAttrsToList (
+      n: v:
+      let
+        specifiedType = finalAttrs.cmakeDefinitionTypes.${n} or "";
+        type =
+          if specifiedType != "" then
+            specifiedType
+          else if lib.isBool v then
+            "bool"
+          else
+            "string";
+      in
+      if lib.toUpper type == "BOOL" then lib.cmakeBool n v else lib.cmakeOptionType type n v
+    ) finalAttrs.cmakeDefinitions;
+
+  doCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Provides numerous sensor models designed to generate realistic data from simulation environments";
+    homepage = "https://github.com/gazebosim/gz-sensors";
+    changelog = "https://github.com/gazebosim/gz-sensors/blob/${finalAttrs.src.rev}/Changelog.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+    mainProgram = "gz-sensors";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/gz/gz-sim/package.nix
+++ b/pkgs/by-name/gz/gz-sim/package.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  gz-cmake,
+  gz-common,
+  gz-fuel-tools,
+  # gz-gui,
+  gz-math,
+  gz-msgs,
+  # gz-physics,
+  # gz-plugin,
+  # gz-rendoring,
+  # gz-sensors,
+  gz-tools,
+  # gz-transport,
+  gz-utils,
+  protobuf,
+# sdformat,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "gz-sim";
+  version = "9.0.0";
+
+  src = fetchFromGitHub {
+    owner = "gazebosim";
+    repo = "gz-sim";
+    rev = "gz-sim${lib.head (lib.splitString "." finalAttrs.version)}_${finalAttrs.version}";
+    hash = "sha256-gsWKknqcTiJc4YHIkmg1YGItwHG1As2OUnpPBQIwqj8=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    gz-cmake
+    gz-common
+    gz-fuel-tools
+    # gz-gui,
+    gz-math
+    gz-msgs
+    # gz-physics
+    # gz-plugin
+    # gz-rendering
+    # gz-sensors
+    gz-tools
+    # gz-transport
+    gz-utils
+    protobuf
+    # sdformat
+  ];
+
+  strictDeps = true;
+
+  cmakeDefinitions = {
+    SKIP_PYBIND11 = true;
+  };
+
+  cmakeFlags =
+    # TODO(@ShamrockLee):
+    # Remove after a unified way to specify CMake definitions becomes available.
+    lib.mapAttrsToList (
+      n: v:
+      let
+        specifiedType = finalAttrs.cmakeDefinitionTypes.${n} or "";
+        type =
+          if specifiedType != "" then
+            specifiedType
+          else if lib.isBool v then
+            "bool"
+          else
+            "string";
+      in
+      if lib.toUpper type == "BOOL" then lib.cmakeBool n v else lib.cmakeOptionType type n v
+    ) finalAttrs.cmakeDefinitions;
+
+  doCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Gazebo, the open source robotics simulator";
+    homepage = "https://github.com/gazebosim/gz-sim";
+    changelog = "https://github.com/gazebosim/gz-sim/blob/${finalAttrs.src.rev}/Changelog.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+    mainProgram = "gz-sim";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/gz/gz-sim/package.nix
+++ b/pkgs/by-name/gz/gz-sim/package.nix
@@ -7,15 +7,15 @@
   gz-cmake,
   gz-common,
   gz-fuel-tools,
-  # gz-gui,
+  gz-gui,
   gz-math,
   gz-msgs,
-  # gz-physics,
-  # gz-plugin,
-  # gz-rendoring,
-  # gz-sensors,
+  gz-physics,
+  gz-plugin,
+  gz-rendering,
+  gz-sensors,
   gz-tools,
-  # gz-transport,
+  gz-transport,
   gz-utils,
   protobuf,
 # sdformat,
@@ -41,15 +41,15 @@ stdenv.mkDerivation (finalAttrs: {
     gz-cmake
     gz-common
     gz-fuel-tools
-    # gz-gui,
+    gz-gui
     gz-math
     gz-msgs
-    # gz-physics
-    # gz-plugin
-    # gz-rendering
-    # gz-sensors
+    gz-physics
+    gz-plugin
+    gz-rendering
+    gz-sensors
     gz-tools
-    # gz-transport
+    gz-transport
     gz-utils
     protobuf
     # sdformat

--- a/pkgs/by-name/gz/gz-tools/package.nix
+++ b/pkgs/by-name/gz/gz-tools/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  backward-cpp,
+  gz-cmake,
+  ruby,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "gz-tools";
+  version = "2.0.2";
+
+  src = fetchFromGitHub {
+    owner = "gazebosim";
+    repo = "gz-tools";
+    rev = "gz-tools${lib.head (lib.splitString "." finalAttrs.version)}_${finalAttrs.version}";
+    hash = "sha256-CY+W1jWIkszKwKuLgKmJpZMXHn0RnueMHFSDhOXIzLg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs =
+    [
+      gz-cmake
+      ruby
+    ]
+    ++ lib.optionals finalAttrs.cmakeDefinitions.USE_SYSTEM_BACKWARDCPP [
+      backward-cpp
+    ];
+
+  strictDeps = true;
+
+  cmakeDefinitions = {
+    # gz-tools requires the system backward-cpp
+    # to provide BackwardCpp.cmake or backward-cpp.cmak,
+    # which is currently not the case in Nixpkgs.
+    USE_SYSTEM_BACKWARDCPP = false;
+  };
+
+  cmakeFlags =
+    # TODO(@ShamrockLee):
+    # Remove after a unified way to specify CMake definitions becomes available.
+    lib.mapAttrsToList (
+      n: v:
+      let
+        specifiedType = finalAttrs.cmakeDefinitionTypes.${n} or "";
+        type =
+          if specifiedType != "" then
+            specifiedType
+          else if lib.isBool v then
+            "bool"
+          else
+            "string";
+      in
+      if lib.toUpper type == "BOOL" then lib.cmakeBool n v else lib.cmakeOptionType type n v
+    ) finalAttrs.cmakeDefinitions;
+
+  passthru = {
+    tests = {
+      check = finalAttrs.finalPackage.overrideAttrs {
+        doCheck = true;
+
+        nativeCheckInputs = [
+          ruby
+        ];
+      };
+    };
+
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Command line tools for the Gazebo libraries";
+    homepage = "https://github.com/gazebosim/gz-tools";
+    changelog = "https://github.com/gazebosim/gz-tools/blob/${finalAttrs.src.rev}/Changelog.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+    mainProgram = "gz";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/gz/gz-transport/package.nix
+++ b/pkgs/by-name/gz/gz-transport/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  gz-cmake,
+  gz-msgs,
+  gz-tools
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "gz-transport";
+  version = "14.0.0";
+
+  src = fetchFromGitHub {
+    owner = "gazebosim";
+    repo = "gz-transport";
+    rev = "gz-transport${lib.head (lib.splitString "." finalAttrs.version)}_${finalAttrs.version}";
+    hash = "sha256-zoGphy2cpmqJsnyS1LNVm4eGtHCWkAwIblga4RdVj4k=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    gz-cmake
+    gz-msgs
+    gz-tools
+  ];
+
+  strictDeps = true;
+
+  cmakeFlags =
+    # TODO(@ShamrockLee):
+    # Remove after a unified way to specify CMake definitions becomes available.
+    lib.mapAttrsToList (
+      n: v:
+      let
+        specifiedType = finalAttrs.cmakeDefinitionTypes.${n} or "";
+        type =
+          if specifiedType != "" then
+            specifiedType
+          else if lib.isBool v then
+            "bool"
+          else
+            "string";
+      in
+      if lib.toUpper type == "BOOL" then lib.cmakeBool n v else lib.cmakeOptionType type n v
+    ) finalAttrs.cmakeDefinitions;
+
+  doCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Transport library for component communication based on publication/subscription and service calls";
+    homepage = "https://github.com/gazebosim/gz-transport";
+    changelog = "https://github.com/gazebosim/gz-transport/blob/${finalAttrs.src.rev}/Changelog.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+    mainProgram = "gz-transport";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/gz/gz-utils/package.nix
+++ b/pkgs/by-name/gz/gz-utils/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  gz-cmake,
+  spdlog,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gz-utils";
+  version = "3.0.0";
+
+  src = fetchFromGitHub {
+    owner = "gazebosim";
+    repo = "gz-utils";
+    rev = "gz-utils${lib.head (lib.splitString "." finalAttrs.version)}_${finalAttrs.version}";
+    hash = "sha256-maq0iGCGbrjVGwBNNIYYSAKXxszwlAJS4FLrGNxsA5c=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    gz-cmake
+    spdlog
+  ];
+
+  strictDeps = true;
+
+  doCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Gazebo Utils, classes and functions for robot applications";
+    homepage = "https://github.com/gazebosim/gz-utils";
+    changelog = "https://github.com/gazebosim/gz-utils/blob/${finalAttrs.src.rev}/Changelog.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+    mainProgram = "gz-utils";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
I've added packages for all the remaining dependencies except `sdformat` using the template you've created. This is a very hastily constructed set of package definitions, and I neglected to specify external dependencies or test anything, so I'm sure there is still a lot of work to do. However, this should lay the basic groundwork for the completion of the `gz-sim` package once `sdformat` is successfully packaged and the correct external dependencies are integrated. Feel free to convert this to a full PR and merge if you want to integrate these changes.